### PR TITLE
Refactor tests to use numpy solver

### DIFF
--- a/laserpad/geometry.py
+++ b/laserpad/geometry.py
@@ -1,13 +1,47 @@
-import fipy as fp
+"""Simple NumPy-based radial mesh utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
 
 
-def build_mesh(r_inner: float, r_outer: float, n_r: int = 100) -> fp.Grid1D:
-    """Build a 1D radial mesh from ``r_inner`` to ``r_outer`` with ``n_r`` cells."""
+@dataclass
+class Mesh:
+    """Uniform 1D radial mesh."""
+
+    r: np.ndarray
+    dr: float
+
+    @property
+    def r_inner(self) -> float:
+        return float(self.r[0] - self.dr / 2)
+
+    @property
+    def r_outer(self) -> float:
+        return float(self.r[-1] + self.dr / 2)
+
+
+def build_mesh(r_inner: float, r_outer: float, n_r: int = 100) -> Mesh:
+    """Build a uniform radial mesh.
+
+    Parameters
+    ----------
+    r_inner:
+        Inner radius.
+    r_outer:
+        Outer radius.
+    n_r:
+        Number of cells.
+
+    Returns
+    -------
+    Mesh
+        Mesh dataclass containing cell centres and spacing.
+    """
+
     dr = (r_outer - r_inner) / n_r
+    r = np.linspace(r_inner + dr / 2, r_outer - dr / 2, n_r)
+    return Mesh(r=r, dr=dr)
 
-    # Build a uniform mesh spanning ``[0, r_outer - r_inner]`` then translate
-    # it so that the first face coincides with ``r_inner``.
-    base = fp.Grid1D(nx=n_r, dx=dr)
-    mesh = base + (r_inner,)
-
-    return mesh

--- a/laserpad/solver.py
+++ b/laserpad/solver.py
@@ -1,46 +1,45 @@
-"""Analytic steady-state solver for radial conduction."""
+"""Temperature solver for the radial conduction problem."""
 
 from __future__ import annotations
 
-import fipy as fp
 import numpy as np
 
+from .geometry import Mesh
 
+
+def solve(
+    mesh: Mesh,
+    q_inner: float,
+    k: float = 400.0,
+    h: float = 1_000.0,
+    T_inf: float = 0.0,
+) -> np.ndarray:
+    """Compute the steady-state temperature profile.
+
+    The analytic solution of the radial conduction equation with an imposed
+    inner heat flux and an outer convective boundary condition is used. The
+    function returns the temperature at the mesh cell centres.
+    """
+
+    r_inner = mesh.r_inner
+    r_outer = mesh.r_outer
+    r = mesh.r
+
+    coeff = q_inner * r_inner / k
+    B = T_inf + coeff * np.log(r_outer) + (q_inner * r_inner) / (h * r_outer)
+    return B - coeff * np.log(r)
+
+
+# Backwards compatibility
 def solve_steady(
-    mesh: fp.Grid1D,
+    mesh: Mesh,
     q_inner: float,
     k: float = 400.0,
     r_outer: float | None = None,
     h: float = 1_000.0,
     T_inf: float = 0.0,
     r_inner: float | None = None,
-) -> fp.CellVariable:
-    """Return the steady-state temperature profile on ``mesh``.
-    The governing equation is the axisymmetric steady conduction problem with a
-    prescribed heat flux ``q_inner`` at ``r_inner`` and a convective boundary at
-    ``r_outer``.  The solution is derived analytically instead of solving a
-    linear system with FiPy.
-    """
-    # Infer radii from the mesh faces if not provided
-    if r_inner is None:
-        r_inner = float(mesh.faceCenters[0].value.min())
-    if r_outer is None:
-        r_outer = float(mesh.faceCenters[0].value.max())
-    r = mesh.cellCenters[0].value
-    # Analytic solution with convection imposed at ``r_outer``
-    # -------------------------------------------------------
-    # For a radial domain r_inner <= r <= r_outer with flux ``q_inner`` entering
-    # at the inner boundary and convection to ``T_inf`` at the outer boundary,
-    # the temperature profile is
-    #
-    #   T(r) = B - (q_inner * r_inner / k) * ln(r)
-    #   B = T_inf + (q_inner * r_inner) / (h * r_outer)
-    #       + (q_inner * r_inner / k) * ln(r_outer)
-    #
-    # The above ensures heat balance: the outer face temperature satisfies
-    # ``-k dT/dr(r_outer) = h (T(r_outer) - T_inf)``.
-    coeff = q_inner * r_inner / k
-    B = T_inf + coeff * np.log(r_outer) + (q_inner * r_inner) / (h * r_outer)
-    values = B - coeff * np.log(r)
+) -> np.ndarray:
+    """Compatibility wrapper retaining the old API."""
 
-    return fp.CellVariable(mesh=mesh, name="temperature", value=values)
+    return solve(mesh, q_inner=q_inner, k=k, h=h, T_inf=T_inf)

--- a/tests/test_m1.py
+++ b/tests/test_m1.py
@@ -2,14 +2,13 @@
 
 import numpy as np
 import pytest
-import fipy as fp
 
-from laserpad.geometry import build_mesh
-from laserpad.solver import solve_steady
+from laserpad.geometry import build_mesh, Mesh
+from laserpad.solver import solve
 
 
 @pytest.fixture(scope="module")
-def mesh_and_temp() -> tuple[fp.Grid1D, fp.CellVariable]:
+def mesh_and_temp() -> tuple[Mesh, np.ndarray]:
     # Default parameters from spec:
     r_inner = 0.50
     r_outer = 1.50
@@ -17,26 +16,23 @@ def mesh_and_temp() -> tuple[fp.Grid1D, fp.CellVariable]:
     n_r = 100
 
     mesh = build_mesh(r_inner=r_inner, r_outer=r_outer, n_r=n_r)
-    r_cells = mesh.cellCenters[0].value
-    print(f"Cell centers: min={r_cells.min():.4f}, max={r_cells.max():.4f}")
-    temperature = solve_steady(mesh=mesh, q_inner=q_flux, k=400.0, r_outer=r_outer)
+    temperature = solve(mesh=mesh, q_inner=q_flux, k=400.0, h=1_000.0, T_inf=0.0)
 
     return mesh, temperature
 
 
-def test_delta_T_large(mesh_and_temp: tuple[fp.Grid1D, fp.CellVariable]) -> None:
+def test_delta_T_large(mesh_and_temp: tuple[Mesh, np.ndarray]) -> None:
     """Test 1: Ensure that max ΔT across the ring is > 10 K."""
     mesh, temperature = mesh_and_temp
-    T_vals = temperature.value.copy()
-    delta_T = np.max(T_vals) - np.min(T_vals)
+    delta_T = float(np.max(temperature) - np.min(temperature))
     assert delta_T > 10.0, f"ΔT too small: {delta_T:.4f} K; expected > 10 K."
 
 
-def test_monotonic_decrease(mesh_and_temp: tuple[fp.Grid1D, fp.CellVariable]) -> None:
+def test_monotonic_decrease(mesh_and_temp: tuple[Mesh, np.ndarray]) -> None:
     """Test 2: Ensure T(r) is monotonically decreasing with r."""
     mesh, temperature = mesh_and_temp
-    r_cell = mesh.cellCenters[0].value.copy()
-    T_vals = temperature.value.copy()
+    r_cell = mesh.r.copy()
+    T_vals = temperature.copy()
 
     # Sort by radius just in case (though mesh is already ordered)
     idx_sort = np.argsort(r_cell)
@@ -48,13 +44,13 @@ def test_monotonic_decrease(mesh_and_temp: tuple[fp.Grid1D, fp.CellVariable]) ->
     ), "Temperature is not monotonically decreasing with radius."
 
 
-def test_energy_balance_flux(mesh_and_temp: tuple[fp.Grid1D, fp.CellVariable]) -> None:
+def test_energy_balance_flux(mesh_and_temp: tuple[Mesh, np.ndarray]) -> None:
     """Inner heat-flux ≈ outer convective heat-loss (< 1 % mismatch)."""
     import math
 
     mesh, temperature = mesh_and_temp
-    r_cell = mesh.cellCenters[0].value.copy()
-    dr = mesh.dx
+    r_cell = mesh.r
+    dr = mesh.dr
 
     r_inner = float(r_cell.min() - dr / 2)
     r_outer = float(r_cell.max() + dr / 2)
@@ -65,11 +61,9 @@ def test_energy_balance_flux(mesh_and_temp: tuple[fp.Grid1D, fp.CellVariable]) -
 
     q_in = q_inner * 2 * math.pi * r_inner
 
-    T_vals = temperature.value
-    r_vals = mesh.cellCenters[0].value
-    T_outer_face = T_vals[-1] + (T_vals[-1] - T_vals[-2]) / (
-        r_vals[-1] - r_vals[-2]
-    ) * (r_outer - r_vals[-1])
+    T_outer_face = temperature[-1] + (temperature[-1] - temperature[-2]) / (
+        r_cell[-1] - r_cell[-2]
+    ) * (r_outer - r_cell[-1])
     q_out = -h * (T_outer_face - T_inf) * 2 * math.pi * r_outer
 
     imbalance = abs(q_in + q_out) / abs(q_in)


### PR DESCRIPTION
## Summary
- add a lightweight NumPy-based `Mesh` helper
- provide a pure NumPy steady solver with compatibility alias
- update M1 tests to use new mesh and solver

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457bb3e9a8832c82116b67a67d7665