### PR TITLE
Implement lumped‑parameter heatup demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-﻿# Laser-Pad-Thermal
+# Laser-Pad-Thermal
 
-Milestone 1 – heat-transfer demo. Validation relies on an energy-balance check
-between the imposed inner heat flux and the convective loss at the outer rim.
+This repository contains a small Streamlit demo for heating a circular copper pad using a lumped thermal model (Milestone 1).
+
+The pad properties are computed from its diameter and thickness. Temperature rise is integrated in time assuming all laser power is absorbed.
+
+Run the interactive demo with:
+
+```bash
+poetry run demo-m1
+```

--- a/laserpad/geometry.py
+++ b/laserpad/geometry.py
@@ -1,17 +1,29 @@
+"""Pad geometry utilities."""
+
 from __future__ import annotations
 
-import numpy as np
+import math
+from typing import Dict
 
 
-def build_mesh(
-    r_inner: float, r_outer: float, n_r: int = 100
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return cell centres and cell widths for a 1‑D radial mesh."""
+def get_pad_properties(
+    diameter_mm: float,
+    thickness_mm: float = 0.035,
+    density: float = 8960.0,
+    cp: float = 385.0,
+) -> Dict[str, float]:
+    """Return area, volume, mass and heat capacity for a circular pad."""
+    diameter_m = diameter_mm / 1000.0
+    thickness_m = thickness_mm / 1000.0
 
-    dr = (r_outer - r_inner) / n_r
-    r_edges = np.linspace(r_inner, r_outer, n_r + 1)
-    r_centres = (r_edges[:-1] + r_edges[1:]) / 2
+    area_m2 = math.pi * (diameter_m / 2.0) ** 2
+    volume_m3 = area_m2 * thickness_m
+    mass_kg = density * volume_m3
+    heat_capacity_J_per_K = mass_kg * cp
 
-    dr_array = np.full_like(r_centres, dr)
-
-    return r_centres, dr_array
+    return {
+        "area_m2": area_m2,
+        "volume_m3": volume_m3,
+        "mass_kg": mass_kg,
+        "heat_capacity_J_per_K": heat_capacity_J_per_K,
+    }

--- a/laserpad/plot.py
+++ b/laserpad/plot.py
@@ -1,54 +1,18 @@
-# laserpad/plot.py
+"""Plot helpers for the lumped heatup model."""
 
-import numpy as np
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.figure import Figure
+from numpy.typing import NDArray
 
 
-def plot_ring(
-    r_centres: np.ndarray, temperature: np.ndarray, r_inner: float, r_outer: float
-) -> Figure:
-    """Create a polar-colored 2D plot of temperature on an annular ring.
-
-    We take the 1D radial solution (mesh + temperature) and spin it around θ ∈ [0, 2π]
-    to produce a “donut-shaped” pcolormesh.
-
-    Args:
-        r_centres: Radial cell centres.
-        temperature: Temperature array matching ``r_centres``.
-        r_inner: Inner radius of the ring.
-        r_outer: Outer radius of the ring.
-
-    Returns:
-        A Matplotlib Figure with a polar pcolormesh, and a colorbar labeled “°C”.
-    """
-    n_r = len(r_centres)
-
-    # Build radial edges (n_r + 1):
-    r_edges = np.linspace(r_inner, r_outer, n_r + 1)
-
-    # Number of angular divisions for smooth ring:
-    n_theta = 200
-    theta_edges = np.linspace(0.0, 2.0 * np.pi, n_theta + 1)
-
-    # Build a meshgrid in (θ, r) for the boundaries:
-    Theta, R = np.meshgrid(theta_edges, r_edges)
-
-    # Build the 2D Z-array: each ring cell has a constant T from the 1D solution:
-    # temperature.value has length n_r. We want shape (n_r, n_theta), so broadcast:
-    Z = np.zeros((n_r, n_theta))
-    for i in range(n_r):
-        Z[i, :] = float(temperature[i])
-
-    # Create polar plot:
-    fig = plt.figure(figsize=(6, 6))
-    ax = fig.add_subplot(111, projection="polar")
-    pcm = ax.pcolormesh(Theta, R, Z, shading="auto")
-    cb = fig.colorbar(pcm, ax=ax)
-    cb.set_label("°C")
-    ax.set_title("Steady-State Temperature on Annular Copper Pad")
-    ax.set_ylim((r_inner, r_outer))
-    ax.set_yticks([])
-    ax.set_xticks([])
-
+def plot_heatup(times: NDArray[np.float_], temps: NDArray[np.float_]) -> Figure:
+    """Return a Matplotlib Figure showing temperature rise."""
+    fig, ax = plt.subplots()
+    ax.plot(times, temps)
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Temperature (°C)")
+    ax.set_title("Pad Temperature")
     return fig

--- a/laserpad/solver.py
+++ b/laserpad/solver.py
@@ -1,27 +1,23 @@
-"""Steady-state solver for radial conduction using NumPy."""
+"""Simple lumped-parameter heatup solver."""
 
 from __future__ import annotations
 
 import numpy as np
+from numpy.typing import NDArray
 
 
-def solve_steady(
-    r_centres: np.ndarray,
-    dr: np.ndarray,
-    q_inner: float,
-    k: float = 400.0,
-    r_outer: float | None = None,
-    h: float = 1_000.0,
-    T_inf: float = 0.0,
-    r_inner: float | None = None,
-) -> np.ndarray:
-    """Return the steady-state temperature profile on the radial mesh."""
-    if r_inner is None:
-        r_inner = float(r_centres[0] - dr[0] / 2)
-    if r_outer is None:
-        r_outer = float(r_centres[-1] + dr[-1] / 2)
-
-    coeff = q_inner * r_inner / k
-    B = T_inf + coeff * np.log(r_outer) + (q_inner * r_inner) / (h * r_outer)
-    values = B - coeff * np.log(r_centres)
-    return values
+def solve_heatup(
+    power_W: float,
+    m_kg: float,
+    cp: float,
+    t_max: float = 1.0,
+    dt: float = 0.01,
+    T0: float = 25.0,
+) -> tuple[NDArray[np.float_], NDArray[np.float_]]:
+    """Integrate dT/dt = power/(m*cp) with explicit Euler."""
+    times: NDArray[np.float_] = np.arange(0.0, t_max + dt, dt)
+    temps: NDArray[np.float_] = np.empty_like(times)
+    temps[0] = T0
+    for i in range(len(times) - 1):
+        temps[i + 1] = temps[i] + (power_W / (m_kg * cp)) * dt
+    return times, temps

--- a/tests/test_m1.py
+++ b/tests/test_m1.py
@@ -1,73 +1,10 @@
-# tests/test_m1.py
-
-import numpy as np
-import pytest
-
-from laserpad.geometry import build_mesh
-from laserpad.solver import solve_steady
+from laserpad.geometry import get_pad_properties
+from laserpad.solver import solve_heatup
 
 
-@pytest.fixture(scope="module")
-def mesh_and_temp() -> tuple[np.ndarray, np.ndarray, float]:
-    # Default parameters from spec:
-    r_inner = 0.50
-    r_outer = 1.50
-    q_flux = 1.0e6
-    n_r = 100
-
-    r_centres, dr = build_mesh(r_inner=r_inner, r_outer=r_outer, n_r=n_r)
-    temperature = solve_steady(
-        r_centres=r_centres, dr=dr, q_inner=q_flux, k=400.0, r_outer=r_outer
+def test_heatup_positive_delta() -> None:
+    props = get_pad_properties(1.0)
+    times, temps = solve_heatup(
+        1000.0, props["mass_kg"], props["heat_capacity_J_per_K"], 0.1, 0.02, 25.0
     )
-
-    return r_centres, temperature, dr[0]
-
-
-def test_delta_T_large(mesh_and_temp: tuple[np.ndarray, np.ndarray, float]) -> None:
-    """Test 1: Ensure that max ΔT across the ring is > 10 K."""
-    r_centres, temperature, _ = mesh_and_temp
-    T_vals = temperature.copy()
-    delta_T = np.max(T_vals) - np.min(T_vals)
-    assert delta_T > 10.0, f"ΔT too small: {delta_T:.4f} K; expected > 10 K."
-
-
-def test_monotonic_decrease(mesh_and_temp: tuple[np.ndarray, np.ndarray, float]) -> None:
-    """Test 2: Ensure T(r) is monotonically decreasing with r."""
-    r_cell, T_vals, _ = mesh_and_temp
-    r_cell = r_cell.copy()
-    T_vals = T_vals.copy()
-
-    # Sort by radius just in case (though mesh is already ordered)
-    idx_sort = np.argsort(r_cell)
-    T_sorted = T_vals[idx_sort]
-    # Check that each subsequent T is <= previous T (monotonic non-increasing)
-    diffs = np.diff(T_sorted)
-    assert np.all(
-        diffs <= 1e-8
-    ), "Temperature is not monotonically decreasing with radius."
-
-
-def test_energy_balance_flux(mesh_and_temp: tuple[np.ndarray, np.ndarray, float]) -> None:
-    """Inner heat-flux ≈ outer convective heat-loss (< 1 % mismatch)."""
-    import math
-
-    r_cell, temperature, dr = mesh_and_temp
-
-    r_inner = float(r_cell.min() - dr / 2)
-    r_outer = float(r_cell.max() + dr / 2)
-
-    q_inner = 1.0e6
-    h = 1_000.0
-    T_inf = 0.0
-
-    q_in = q_inner * 2 * math.pi * r_inner
-
-    T_vals = temperature
-    r_vals = r_cell
-    T_outer_face = T_vals[-1] + (T_vals[-1] - T_vals[-2]) / (
-        r_vals[-1] - r_vals[-2]
-    ) * (r_outer - r_vals[-1])
-    q_out = -h * (T_outer_face - T_inf) * 2 * math.pi * r_outer
-
-    imbalance = abs(q_in + q_out) / abs(q_in)
-    assert imbalance < 0.01, f"Energy imbalance {imbalance*100:.2f}% > 1 %"
+    assert temps[-1] > temps[0]


### PR DESCRIPTION
## Summary
- replace radial PDE code with lumped model helpers
- compute copper pad properties in `get_pad_properties`
- integrate temperature rise with `solve_heatup`
- add simple `plot_heatup` wrapper and Streamlit demo
- update smoke test

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472aebfd18832c99541b82b4305e58