### PR TITLE
Add step limit options across demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ poetry run demo-m5
 
 When the app asks for a trace configuration, upload `sample_traces.json` to see
 a simple demo.
+
+To terminate a running demo and launch another one, press `Ctrl+C` in the
+terminal where Streamlit is running. This stops the server so you can start the
+next demo without closing VS Code.

--- a/demos/demo_m1.py
+++ b/demos/demo_m1.py
@@ -18,7 +18,7 @@ def main() -> None:
     th_mm = st.number_input("Pad thickness (mm)", value=0.035, step=0.005)
     power_mW = st.slider("Laser power (W)", 10.0, 10000.0, 1000.0, step=10.0)
     t_max = st.slider("Total time (s)", 0.1, 5.0, 1.0, step=0.1)
-    dt = st.slider("Time step (s)", 0.001, 0.1, 0.02, step=0.001)
+    dt = st.slider("Time step (s)", 0.001, 0.1, 0.02, step=0.001, format="%.6f")
     T0 = st.number_input("Initial temperature (°C)", value=25.0, step=1.0)
 
     props = get_pad_properties(d_mm, th_mm)

--- a/demos/demo_m2.py
+++ b/demos/demo_m2.py
@@ -21,7 +21,9 @@ def main() -> None:
     k = st.number_input("Thermal conductivity k (W/m/K)", value=401.0)
     rho_cp = st.number_input("rho*cp (J/m^3/K)", value=8960.0 * 385.0)
     t_max_ms = st.number_input("Total time (ms)", value=100.0)
-    dt_ms = st.number_input("Time step (ms)", value=1.0)
+    dt_ms = st.number_input("Time step (ms)", value=1.0, format="%.6f")
+    max_iter = st.number_input("Max steps", value=1000, min_value=1, step=1)
+    allow_unstable = st.checkbox("Ignore stability limit")
 
     if dt_ms < 0.1:
         st.warning("Time step is very small; simulation may be slow and not optimal.")
@@ -39,7 +41,17 @@ def main() -> None:
         )
         r_inner_m = r_inner_mm / 1000.0
         q_flux = power_W / (2.0 * np.pi * r_inner_m)
-        times, T = solve_transient(r_centres, dr, q_flux, k, rho_cp, t_max, dt)
+        times, T = solve_transient(
+            r_centres,
+            dr,
+            q_flux,
+            k,
+            rho_cp,
+            t_max,
+            dt,
+            max_steps=int(max_iter),
+            allow_unstable=allow_unstable,
+        )
         st.session_state["m2_results"] = (r_centres, times, T)
 
     if st.session_state["m2_results"] is not None:

--- a/demos/demo_m4.py
+++ b/demos/demo_m4.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import streamlit as st
+import numpy as np
 
 from laserpad.geometry import build_stack_mesh
 from laserpad.solver import solve_transient_2d
@@ -20,7 +21,9 @@ def main() -> None:
     n_z = st.slider("Axial cells", 10, 200, 50)
     power_W = st.number_input("Laser power Qin (W)", value=10.0)
     n_t = st.slider("Time steps", 10, 200, 50)
-    dt_ms = st.number_input("Time step (ms)", value=0.1)
+    dt_ms = st.number_input("Time step (ms)", value=0.1, format="%.6f")
+    max_iter = st.number_input("Max steps", value=1000, min_value=1, step=1)
+    allow_unstable = st.checkbox("Ignore stability limit")
 
     if dt_ms < 0.01:
         st.warning("Time step is very small; simulation may be slow and not optimal.")
@@ -34,7 +37,16 @@ def main() -> None:
         height = pad_th + sub_th
         q_flux = power_W / (2.0 * np.pi * r_in * height)
         times, T = solve_transient_2d(
-            r_centres, dr, z_centres, dz, mat_idx, q_flux, n_t, dt
+            r_centres,
+            dr,
+            z_centres,
+            dz,
+            mat_idx,
+            q_flux,
+            n_t,
+            dt,
+            max_steps=int(max_iter),
+            allow_unstable=allow_unstable,
         )
         t_idx = st.slider("Time index", 0, len(times) - 1, 0)
         fig = plot_stack_temperature(r_centres, z_centres, T[t_idx])

--- a/demos/demo_m5.py
+++ b/demos/demo_m5.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import streamlit as st
+import numpy as np
 
 from laserpad.geometry import load_traces, build_stack_mesh_with_traces
 from laserpad.solver import solve_transient_2d
@@ -20,7 +21,9 @@ def main() -> None:
     n_z = st.slider("Axial cells", 10, 200, 50)
     power_W = st.number_input("Laser power Qin (W)", value=10.0)
     n_t = st.slider("Time steps", 10, 200, 50)
-    dt_ms = st.number_input("Time step (ms)", value=0.1)
+    dt_ms = st.number_input("Time step (ms)", value=0.1, format="%.6f")
+    max_iter = st.number_input("Max steps", value=1000, min_value=1, step=1)
+    allow_unstable = st.checkbox("Ignore stability limit")
 
     if dt_ms < 0.01:
         st.warning("Time step is very small; simulation may be slow and not optimal.")
@@ -50,6 +53,8 @@ def main() -> None:
             trace_mask=mask,
             h_trace=h_trace,
             T_inf=T_inf,
+            max_steps=int(max_iter),
+            allow_unstable=allow_unstable,
         )
         t_idx = st.slider("Time index", 0, len(times) - 1, 0)
         fig = plot_stack_temperature(r, z, T[t_idx])


### PR DESCRIPTION
## Summary
- show timestep with 6 decimal places in demo M1
- provide controls for max steps and ignoring the stability check in demos M4 and M5

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68482b670f90832c9f4e080a9053140f