### PR TITLE
Improve UX with progress bars and SI formatting

### DIFF
--- a/demos/demo_m1.py
+++ b/demos/demo_m1.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import streamlit as st
+import time
+from matplotlib.ticker import EngFormatter
 
 from laserpad.geometry import get_pad_properties
 from laserpad.solver import solve_heatup
@@ -19,21 +21,50 @@ def main() -> None:
     power_mW = st.slider("Laser power (W)", 10.0, 10000.0, 1000.0, step=10.0)
     t_max = st.slider("Total time (s)", 0.1, 5.0, 1.0, step=0.1)
     dt = st.slider("Time step (s)", 0.001, 0.1, 0.02, step=0.001, format="%.6f")
+    max_iter = st.number_input(
+        "Max iterations per step", min_value=1000, value=10000
+    )
     T0 = st.number_input("Initial temperature (°C)", value=25.0, step=1.0)
 
     props = get_pad_properties(d_mm, th_mm)
+    progress = st.progress(0)
+    status = st.empty()
+    start = time.perf_counter()
+
+    def cb(i: int, total: int) -> None:
+        frac = i / total
+        progress.progress(int(frac * 100))
+        elapsed = time.perf_counter() - start
+        est_total = elapsed / frac if frac else 0.0
+        remaining = est_total - elapsed
+        status.text(
+            f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
+        )
+
     times, temps = solve_heatup(
-        power_mW, props["mass_kg"], props["heat_capacity_J_per_K"], t_max, dt, T0
+        power_mW,
+        props["mass_kg"],
+        props["heat_capacity_J_per_K"],
+        t_max,
+        dt,
+        T0,
+        max_steps=int(max_iter),
+        progress_cb=cb,
     )
+    progress.empty()
+    status.success(f"Completed in {time.perf_counter() - start:.1f}s")
 
     fig = plot_heatup(times, temps)
     st.pyplot(fig)
 
+    eng_temp = EngFormatter(unit="°C", places=2)
+    eng_mass = EngFormatter(unit="kg", places=2)
+    eng_cp = EngFormatter(unit="J/K", places=2)
     st.markdown(
         f"""
-**Pad mass:** {props['mass_kg']:.4f} kg  
-**Heat capacity:** {props['heat_capacity_J_per_K']:.1f} J/K  
-**Peak ΔT:** {(temps[-1]-T0):.1f} °C
+**Pad mass:** {eng_mass.format_data(props['mass_kg'])}
+**Heat capacity:** {eng_cp.format_data(props['heat_capacity_J_per_K'])}
+**Peak ΔT:** {eng_temp.format_data(temps[-1] - T0)}
 """
     )
 

--- a/demos/demo_m5.py
+++ b/demos/demo_m5.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import streamlit as st
 import numpy as np
+import time
+from matplotlib.ticker import EngFormatter
 
 from laserpad.geometry import load_traces, build_stack_mesh_with_traces
 from laserpad.solver import solve_transient_2d
@@ -22,7 +24,9 @@ def main() -> None:
     power_W = st.number_input("Laser power Qin (W)", value=10.0)
     n_t = st.slider("Time steps", 10, 200, 50)
     dt_ms = st.number_input("Time step (ms)", value=0.1, format="%.6f")
-    max_iter = st.number_input("Max steps", value=1000, min_value=1, step=1)
+    max_iter = st.number_input(
+        "Max iterations per step", value=1000, min_value=1, step=1
+    )
     allow_unstable = st.checkbox("Ignore stability limit")
 
     if dt_ms < 0.01:
@@ -41,6 +45,20 @@ def main() -> None:
         )
         height = pad_th + sub_th
         q_flux = power_W / (2.0 * np.pi * r_in * height)
+        progress = st.progress(0)
+        status = st.empty()
+        start = time.perf_counter()
+
+        def cb(i: int, total: int) -> None:
+            frac = i / total
+            progress.progress(int(frac * 100))
+            elapsed = time.perf_counter() - start
+            est_total = elapsed / frac if frac else 0.0
+            remaining = est_total - elapsed
+            status.text(
+                f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
+            )
+
         times, T = solve_transient_2d(
             r,
             dr,
@@ -55,7 +73,10 @@ def main() -> None:
             T_inf=T_inf,
             max_steps=int(max_iter),
             allow_unstable=allow_unstable,
+            progress_cb=cb,
         )
+        progress.empty()
+        status.success(f"Completed in {time.perf_counter() - start:.1f}s")
         t_idx = st.slider("Time index", 0, len(times) - 1, 0)
         fig = plot_stack_temperature(r, z, T[t_idx])
         st.pyplot(fig)

--- a/laserpad/plot.py
+++ b/laserpad/plot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+from matplotlib.ticker import EngFormatter
 import numpy as np
 from matplotlib.figure import Figure
 from matplotlib.axes import Axes
@@ -17,6 +18,8 @@ def plot_heatup(times: NDArray[np.float_], temps: NDArray[np.float_]) -> Figure:
     ax.set_xlabel("Time (s)")
     ax.set_ylabel("Temperature (°C)")
     ax.set_title("Pad Temperature")
+    ax.xaxis.set_major_formatter(EngFormatter(unit="s"))
+    ax.yaxis.set_major_formatter(EngFormatter(unit="°C"))
     return fig
 
 
@@ -29,6 +32,8 @@ def plot_transient(
     (line,) = ax.plot(r_centres, T[0])
     ax.set_xlabel("Radius (m)")
     ax.set_ylabel("Temperature (°C)")
+    ax.xaxis.set_major_formatter(EngFormatter(unit="m"))
+    ax.yaxis.set_major_formatter(EngFormatter(unit="°C"))
 
     def update(frame: int) -> list[Line2D]:
         line.set_ydata(T[frame])
@@ -51,7 +56,11 @@ def plot_stack_temperature(
     fig, ax = plt.subplots()
     R, Z = np.meshgrid(r_centres * 1000.0, z_centres * 1000.0)
     pcm = ax.pcolormesh(R, Z, T_frame, shading="auto")
-    fig.colorbar(pcm, ax=ax, label="Temperature (°C)")
+    cbar = fig.colorbar(pcm, ax=ax, label="Temperature (°C)")
+    cbar.formatter = EngFormatter(unit="°C")
+    cbar.update_ticks()
     ax.set_xlabel("Radius (mm)")
     ax.set_ylabel("z (mm)")
+    ax.xaxis.set_major_formatter(EngFormatter(unit="mm"))
+    ax.yaxis.set_major_formatter(EngFormatter(unit="mm"))
     return fig


### PR DESCRIPTION
## Summary
- add optional progress callback support to solvers
- enhance plot helpers with engineering tick formatting
- implement progress bars and ETA in all Streamlit demos
- show human-friendly numbers using `EngFormatter`

## Testing
- `poetry run pytest -q`
- `poetry run demo-m1`
- `poetry run demo-m2`
- `poetry run demo-m3`
- `poetry run demo-m4`
- `poetry run demo-m5`


------
https://chatgpt.com/codex/tasks/task_e_68483748b3c0832c81bc40444c7e56ee