### PR TITLE
Implement annular pad mass calculation

### DIFF
--- a/demos/demo_m1.py
+++ b/demos/demo_m1.py
@@ -6,7 +6,7 @@ import streamlit as st
 import time
 from matplotlib.ticker import EngFormatter
 
-from laserpad.geometry import get_pad_properties
+from laserpad.geometry import get_annular_pad_properties
 from laserpad.solver import solve_heatup
 from laserpad.plot import plot_heatup
 
@@ -14,19 +14,18 @@ from laserpad.plot import plot_heatup
 def main() -> None:
     st.title("M1: Lumped-Pad Heatup Demo")
 
-    d_mm = st.slider(
-        "Pad diameter (mm)", min_value=0.5, max_value=5.0, value=1.0, step=0.1
+    r_inner_mm = st.number_input("Inner radius (mm)", min_value=0.0, value=0.0)
+    r_outer_mm = st.number_input(
+        "Outer radius (mm)", min_value=0.1, value=0.5, step=0.1
     )
     th_mm = st.number_input("Pad thickness (mm)", value=0.035, step=0.005)
     power_mW = st.slider("Laser power (W)", 10.0, 10000.0, 1000.0, step=10.0)
     t_max = st.slider("Total time (s)", 0.1, 5.0, 1.0, step=0.1)
     dt = st.slider("Time step (s)", 0.001, 0.1, 0.02, step=0.001, format="%.6f")
-    max_iter = st.number_input(
-        "Max iterations per step", min_value=1000, value=10000
-    )
+    max_iter = st.number_input("Max iterations per step", min_value=1000, value=10000)
     T0 = st.number_input("Initial temperature (°C)", value=25.0, step=1.0)
 
-    props = get_pad_properties(d_mm, th_mm)
+    props = get_annular_pad_properties(r_inner_mm, r_outer_mm, th_mm)
     progress = st.progress(0)
     status = st.empty()
     start = time.perf_counter()

--- a/demos/demo_m4.py
+++ b/demos/demo_m4.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import streamlit as st
 import numpy as np
 import time
-from matplotlib.ticker import EngFormatter
 
 from laserpad.geometry import build_stack_mesh
 from laserpad.solver import solve_transient_2d

--- a/demos/demo_m5.py
+++ b/demos/demo_m5.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import streamlit as st
 import numpy as np
 import time
-from matplotlib.ticker import EngFormatter
 
 from laserpad.geometry import load_traces, build_stack_mesh_with_traces
 from laserpad.solver import solve_transient_2d

--- a/laserpad/geometry.py
+++ b/laserpad/geometry.py
@@ -12,27 +12,52 @@ from numpy.typing import NDArray
 import numpy as np
 
 
+def get_annular_pad_properties(
+    r_inner_mm: float,
+    r_outer_mm: float,
+    thickness_mm: float = 0.035,
+    density: float = 8960.0,
+    cp: float = 385.0,
+) -> dict[str, float]:
+    """Return area, volume, mass and heat capacity for an annular pad."""
+
+    r_in = r_inner_mm * 1e-3
+    r_out = r_outer_mm * 1e-3
+    t = thickness_mm * 1e-3
+
+    area = math.pi * (r_out**2 - r_in**2)
+    volume = area * t
+    mass = density * volume
+    heat_capacity = mass * cp
+
+    return {
+        "area_m2": area,
+        "volume_m3": volume,
+        "mass_kg": mass,
+        "heat_capacity_J_per_K": heat_capacity,
+    }
+
+
 def get_pad_properties(
     diameter_mm: float,
     thickness_mm: float = 0.035,
     density: float = 8960.0,
     cp: float = 385.0,
 ) -> Dict[str, float]:
-    """Return area, volume, mass and heat capacity for a circular pad."""
-    diameter_m = diameter_mm / 1000.0
-    thickness_m = thickness_mm / 1000.0
+    """Return properties for a solid circular pad.
 
-    area_m2 = math.pi * (diameter_m / 2.0) ** 2
-    volume_m3 = area_m2 * thickness_m
-    mass_kg = density * volume_m3
-    heat_capacity_J_per_K = mass_kg * cp
+    This function is retained for backward compatibility and simply calls
+    :func:`get_annular_pad_properties` with ``r_inner_mm`` set to 0.
+    """
 
-    return {
-        "area_m2": area_m2,
-        "volume_m3": volume_m3,
-        "mass_kg": mass_kg,
-        "heat_capacity_J_per_K": heat_capacity_J_per_K,
-    }
+    r_out = diameter_mm / 2.0
+    return get_annular_pad_properties(
+        0.0,
+        r_out,
+        thickness_mm,
+        density,
+        cp,
+    )
 
 
 def build_radial_mesh(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,21 @@
+import math
+from laserpad.geometry import get_annular_pad_properties
+
+
+def test_annular_mass_and_heat_capacity() -> None:
+    r_in_mm, r_out_mm = 0.5, 1.5
+    t_mm = 0.035
+    density = 8000.0
+    cp = 250.0
+    props = get_annular_pad_properties(r_in_mm, r_out_mm, t_mm, density, cp)
+    r_in = r_in_mm * 1e-3
+    r_out = r_out_mm * 1e-3
+    t = t_mm * 1e-3
+    area = math.pi * (r_out**2 - r_in**2)
+    volume = area * t
+    mass = density * volume
+    heat_capacity = mass * cp
+    assert math.isclose(props["area_m2"], area, rel_tol=1e-9)
+    assert math.isclose(props["volume_m3"], volume, rel_tol=1e-9)
+    assert math.isclose(props["mass_kg"], mass, rel_tol=1e-9)
+    assert math.isclose(props["heat_capacity_J_per_K"], heat_capacity, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- add `get_annular_pad_properties` for annular pads
- call new function from `get_pad_properties`
- update demo_m1 to use inner/outer radius
- clean up unused imports in M4/M5 demos
- add unit test for annular pad mass/heat capacity

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`
- `python -m py_compile demos/demo_m1.py demos/demo_m2.py demos/demo_m3.py demos/demo_m4.py demos/demo_m5.py`

------
https://chatgpt.com/codex/tasks/task_e_68483ce1e7c0832c8cbffb13ad86d3c7