### PR TITLE
Improve error handling for solver stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ poetry run streamlit run demos/demo_m4.py
 poetry run streamlit run demos/demo_m5.py
 ```
 
+These demos use an explicit time-marching scheme with a stability
+limit on the time step. If you see an error like
+"Time step ... exceeds stability limit ...", reduce the chosen step
+size or enable the **Ignore stability limit** checkbox in the UI.
+
 Run the test suite with:
 
 ```bash

--- a/demos/demo_m2.py
+++ b/demos/demo_m2.py
@@ -40,9 +40,7 @@ def main() -> None:
 
     run = st.button("Run simulation")
     if run:
-        r_centres, dr = build_radial_mesh(
-            r_inner_mm / 1000.0, r_outer_mm / 1000.0, n_r
-        )
+        r_centres, dr = build_radial_mesh(r_inner_mm / 1000.0, r_outer_mm / 1000.0, n_r)
         r_inner_m = r_inner_mm / 1000.0
         q_flux = power_W / (2.0 * np.pi * r_inner_m)
         progress = st.progress(0)
@@ -59,18 +57,23 @@ def main() -> None:
                 f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
             )
 
-        times, T = solve_transient(
-            r_centres,
-            dr,
-            q_flux,
-            k,
-            rho_cp,
-            t_max,
-            dt,
-            max_steps=int(max_iter),
-            allow_unstable=allow_unstable,
-            progress_cb=cb,
-        )
+        try:
+            times, T = solve_transient(
+                r_centres,
+                dr,
+                q_flux,
+                k,
+                rho_cp,
+                t_max,
+                dt,
+                max_steps=int(max_iter),
+                allow_unstable=allow_unstable,
+                progress_cb=cb,
+            )
+        except ValueError as exc:
+            progress.empty()
+            status.error(str(exc))
+            return
         progress.empty()
         status.success(f"Completed in {time.perf_counter() - start:.1f}s")
         st.session_state["m2_results"] = (r_centres, times, T)

--- a/demos/demo_m3.py
+++ b/demos/demo_m3.py
@@ -80,19 +80,24 @@ def main() -> None:
                 f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
             )
 
-        times, T = solve_transient(
-            r_centres,
-            dr,
-            0.0,
-            k,
-            rho_cp,
-            t_max,
-            dt,
-            src,
-            max_steps=int(max_iter),
-            allow_unstable=allow_unstable,
-            progress_cb=cb,
-        )
+        try:
+            times, T = solve_transient(
+                r_centres,
+                dr,
+                0.0,
+                k,
+                rho_cp,
+                t_max,
+                dt,
+                src,
+                max_steps=int(max_iter),
+                allow_unstable=allow_unstable,
+                progress_cb=cb,
+            )
+        except ValueError as exc:
+            progress.empty()
+            status.error(str(exc))
+            return
         progress.empty()
         status.success(f"Completed in {time.perf_counter() - start:.1f}s")
         st.session_state["m3_results"] = (r_centres, times, T, beam_type)

--- a/demos/demo_m4.py
+++ b/demos/demo_m4.py
@@ -53,19 +53,24 @@ def main() -> None:
                 f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
             )
 
-        times, T = solve_transient_2d(
-            r_centres,
-            dr,
-            z_centres,
-            dz,
-            mat_idx,
-            q_flux,
-            n_t,
-            dt,
-            max_steps=int(max_iter),
-            allow_unstable=allow_unstable,
-            progress_cb=cb,
-        )
+        try:
+            times, T = solve_transient_2d(
+                r_centres,
+                dr,
+                z_centres,
+                dz,
+                mat_idx,
+                q_flux,
+                n_t,
+                dt,
+                max_steps=int(max_iter),
+                allow_unstable=allow_unstable,
+                progress_cb=cb,
+            )
+        except ValueError as exc:
+            progress.empty()
+            status.error(str(exc))
+            return
         progress.empty()
         status.success(f"Completed in {time.perf_counter() - start:.1f}s")
         t_idx = st.slider("Time index", 0, len(times) - 1, 0)

--- a/demos/demo_m5.py
+++ b/demos/demo_m5.py
@@ -58,22 +58,27 @@ def main() -> None:
                 f"Iteration {i}/{total} — elapsed {elapsed:.1f}s, ETA {remaining:.1f}s"
             )
 
-        times, T = solve_transient_2d(
-            r,
-            dr,
-            z,
-            dz,
-            mat_idx,
-            q_flux,
-            n_t,
-            dt,
-            trace_mask=mask,
-            h_trace=h_trace,
-            T_inf=T_inf,
-            max_steps=int(max_iter),
-            allow_unstable=allow_unstable,
-            progress_cb=cb,
-        )
+        try:
+            times, T = solve_transient_2d(
+                r,
+                dr,
+                z,
+                dz,
+                mat_idx,
+                q_flux,
+                n_t,
+                dt,
+                trace_mask=mask,
+                h_trace=h_trace,
+                T_inf=T_inf,
+                max_steps=int(max_iter),
+                allow_unstable=allow_unstable,
+                progress_cb=cb,
+            )
+        except ValueError as exc:
+            progress.empty()
+            status.error(str(exc))
+            return
         progress.empty()
         status.success(f"Completed in {time.perf_counter() - start:.1f}s")
         t_idx = st.slider("Time index", 0, len(times) - 1, 0)


### PR DESCRIPTION
## Summary
- handle stability `ValueError` in all Streamlit demos
- document how to deal with the solver stability limit

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483fb8cb7c832cbfb99a34ee882566